### PR TITLE
#348: use shallow clone by default in CI mode

### DIFF
--- a/crates/spaces/src/co.rs
+++ b/crates/spaces/src/co.rs
@@ -52,7 +52,13 @@ pub fn checkout_repo(
     keep_workspace_on_failure: bool,
 ) -> anyhow::Result<()> {
     set_workspace_env(env).context(format_context!("While checking out repo"))?;
-    let clone = clone.unwrap_or(git::Clone::Default);
+
+    // use a shallow clone by default if running in CI
+    let clone = if singleton::get_is_ci() {
+        clone.unwrap_or(git::Clone::Shallow)
+    } else {
+        clone.unwrap_or(git::Clone::Default)
+    };
 
     // get the repo name from the url
     let repo_name = if let Some(rule_name) = rule_name {


### PR DESCRIPTION
Closes #348 

Tested locally via the following workflow:
```shell
spaces shell
cargo install --path=spaces/crates/spaces --root=$HOME/.local --profile=release
exit
which spaces # confirm it is $HOME/.local/bin/spaces
cd ../..
spaces --ci checkout-repo --name test-repo --url https://github.com/russweas/spaces.git --rev main
cd test-repo
git rev-parse --is-shallow-repository 
```